### PR TITLE
chart.js 3 버전대 업데이트로 인한 변경 내용 반영 요청

### DIFF
--- a/project/app.js
+++ b/project/app.js
@@ -168,8 +168,8 @@ async function setupData() {
 
 function renderChart(data, labels) {
   var ctx = $('#lineChart').getContext('2d');
-  Chart.defaults.color = '#f5eaea'
-  Chart.defaults.font.family = 'Exo 2'
+  Chart.defaults.color = '#f5eaea';
+  Chart.defaults.font.family = 'Exo 2';
   new Chart(ctx, {
     type: 'line',
     data: {

--- a/project/app.js
+++ b/project/app.js
@@ -168,8 +168,8 @@ async function setupData() {
 
 function renderChart(data, labels) {
   var ctx = $('#lineChart').getContext('2d');
-  Chart.defaults.global.defaultFontColor = '#f5eaea';
-  Chart.defaults.global.defaultFontFamily = 'Exo 2';
+  Chart.defaults.color = '#f5eaea'
+  Chart.defaults.font.family = 'Exo 2'
   new Chart(ctx, {
     type: 'line',
     data: {


### PR DESCRIPTION
기효님 안녕하세요.
[실전으로 배우는 타입스크립트](https://www.inflearn.com/course/%ED%83%80%EC%9E%85%EC%8A%A4%ED%81%AC%EB%A6%BD%ED%8A%B8-%EC%8B%A4%EC%A0%84) 강의 잘 보고 있습니다. 🙇‍♂️ 

강의 실습을 따라하던 도중 이슈가 있는 부분이 있어서 제보 드립니다.

최근 chart.js가 3.x 버전으로 메이저 버전이 업데이트 되었는데요. (https://github.com/chartjs/Chart.js/tags)
(기존 2.8에서는 정의가 안되어 있던 types 내용도 3 버전에서 추가되긴 하였지만 강의 실습에 문제는 없었습니다.)

deprecated된 font 관련 속성들이 현재 코드에 남아있어 변경 내용 PR 올려봅니다.

### 관련 링크
- https://www.chartjs.org/docs/master/getting-started/v3-migration.html#defaults

### 변경 내용
- global namespace 제거
- defaultFontColor -> color로 변경
- defaultFontFamily -> font.family로 변경